### PR TITLE
ADD: option to disable null filtered index checks on spanner emulator

### DIFF
--- a/spanner_orm/field.py
+++ b/spanner_orm/field.py
@@ -185,6 +185,7 @@ class String(FieldType):
         if not isinstance(value, str):
             raise error.ValidationError("{} is not of type str".format(value))
 
+
 class Bytes(FieldType):
     """Represents a bytes type."""
 


### PR DESCRIPTION
### Problem we are trying to solve
When using the `spanner_orm.force_index` option on null filtered indexes, we loose the ability to the query with the spanner emulator. 
For instance, setting the option
```python
spanner_orm.force_index('index_name')
```
and testing with the spanner emulator, gives us this error:

> "The emulator is not able to determine whether the null filtered index index_name can be used to answer this query as it may filter out nulls that may be required to answer the query. Please test this query against Cloud Spanner. If you confirm against Cloud Spanner that the null filtered index can be used to answer the query, set the hint @{spanner_emulator.disable_query_null_filtered_index_check=true} on the table to bypass this check in the emulator. This hint will be ignored by the production Cloud Spanner service and the emulator will accept the query and return a valid result when it is run with the check disabled."

### Solution
We create a parameter in the `force_index` option to disable the null filtered index check.
```python
spanner_orm.force_index('index_name', emulator_disable_null_filtered_check=True)
```