### PR TITLE
chore(ccore-1335): update spanner library and add json field type

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ from setuptools import setup
 
 setup(
     name="spanner-orm",
-    version="0.5.1",
+    version="0.5.3",
     description="Basic ORM for Spanner",
     maintainer="Aniruddha Maru",
     maintainer_email="aniruddhamaru@gmail.com",

--- a/setup.py
+++ b/setup.py
@@ -25,10 +25,10 @@ setup(
     packages=["spanner_orm", "spanner_orm.admin"],
     include_package_data=True,
     python_requires="~=3.7",
-    install_requires=["wheel", "google-cloud-spanner >= 1.6, <2.0.0dev"],
+    install_requires=["wheel", "google-cloud-spanner>=3.44.0,<4.0.0"],
     tests_require=["absl-py"],
     extras_require={
-        "tests": ["black==20.8b1"],
+        "tests": ["black==23.3.0"],
     },
     entry_points={"console_scripts": ["spanner-orm = spanner_orm.admin.scripts:main"]},
 )

--- a/spanner_orm/field.py
+++ b/spanner_orm/field.py
@@ -20,8 +20,7 @@ from typing import Any, Type, Optional
 
 from spanner_orm import error
 
-from google.cloud.spanner_v1 import COMMIT_TIMESTAMP
-from google.cloud.spanner_v1.proto import type_pb2
+from google.cloud.spanner_v1 import COMMIT_TIMESTAMP, Type as SpannerType, TypeCode
 
 
 class FieldType(abc.ABC):
@@ -34,7 +33,7 @@ class FieldType(abc.ABC):
 
     @staticmethod
     @abc.abstractmethod
-    def grpc_type() -> type_pb2.Type:
+    def grpc_type() -> SpannerType:
         raise NotImplementedError
 
     @staticmethod
@@ -126,8 +125,8 @@ class Boolean(FieldType):
         return "BOOL"
 
     @staticmethod
-    def grpc_type() -> type_pb2.Type:
-        return type_pb2.Type(code=type_pb2.BOOL)
+    def grpc_type() -> SpannerType:
+        return SpannerType(code=TypeCode.BOOL)
 
     @staticmethod
     def validate_type(value: Any) -> None:
@@ -143,8 +142,8 @@ class Integer(FieldType):
         return "INT64"
 
     @staticmethod
-    def grpc_type() -> type_pb2.Type:
-        return type_pb2.Type(code=type_pb2.INT64)
+    def grpc_type() -> SpannerType:
+        return SpannerType(code=TypeCode.INT64)
 
     @staticmethod
     def validate_type(value: Any) -> None:
@@ -160,8 +159,8 @@ class Float(FieldType):
         return "FLOAT64"
 
     @staticmethod
-    def grpc_type() -> type_pb2.Type:
-        return type_pb2.Type(code=type_pb2.FLOAT64)
+    def grpc_type() -> SpannerType:
+        return SpannerType(code=TypeCode.FLOAT64)
 
     @staticmethod
     def validate_type(value: Any) -> None:
@@ -177,8 +176,8 @@ class String(FieldType):
         return "STRING({size})".format(size=size)
 
     @staticmethod
-    def grpc_type() -> type_pb2.Type:
-        return type_pb2.Type(code=type_pb2.STRING)
+    def grpc_type() -> SpannerType:
+        return SpannerType(code=TypeCode.STRING)
 
     @staticmethod
     def validate_type(value) -> None:
@@ -194,8 +193,8 @@ class Bytes(FieldType):
         return "BYTES({size})".format(size=size)
 
     @staticmethod
-    def grpc_type() -> type_pb2.Type:
-        return type_pb2.Type(code=type_pb2.BYTES)
+    def grpc_type() -> SpannerType:
+        return SpannerType(code=TypeCode.BYTES)
 
     @staticmethod
     def validate_type(value) -> None:
@@ -211,8 +210,8 @@ class Bytes(FieldType):
         return "BYTES({size})".format(size=size)
 
     @staticmethod
-    def grpc_type() -> type_pb2.Type:
-        return type_pb2.Type(code=type_pb2.BYTES)
+    def grpc_type() -> SpannerType:
+        return SpannerType(code=TypeCode.BYTES)
 
     @staticmethod
     def validate_type(value) -> None:
@@ -228,8 +227,8 @@ class Date(FieldType):
         return "DATE"
 
     @staticmethod
-    def grpc_type() -> type_pb2.Type:
-        return type_pb2.Type(code=type_pb2.DATE)
+    def grpc_type() -> SpannerType:
+        return SpannerType(code=TypeCode.DATE)
 
     @staticmethod
     def validate_type(value) -> None:
@@ -249,8 +248,8 @@ class StringArray(FieldType):
         return "ARRAY<STRING({size})>".format(size=size)
 
     @staticmethod
-    def grpc_type() -> type_pb2.Type:
-        return type_pb2.Type(code=type_pb2.ARRAY)
+    def grpc_type() -> SpannerType:
+        return SpannerType(code=TypeCode.ARRAY)
 
     @staticmethod
     def validate_type(value: Any) -> None:
@@ -269,8 +268,8 @@ class BoolArray(FieldType):
         return "ARRAY<BOOL>"
 
     @staticmethod
-    def grpc_type() -> type_pb2.Type:
-        return type_pb2.Type(code=type_pb2.ARRAY)
+    def grpc_type() -> SpannerType:
+        return SpannerType(code=TypeCode.ARRAY)
 
     @staticmethod
     def validate_type(value: Any) -> None:
@@ -289,8 +288,8 @@ class IntegerArray(FieldType):
         return "ARRAY<INT64>"
 
     @staticmethod
-    def grpc_type() -> type_pb2.Type:
-        return type_pb2.Type(code=type_pb2.ARRAY)
+    def grpc_type() -> SpannerType:
+        return SpannerType(code=TypeCode.ARRAY)
 
     @staticmethod
     def validate_type(value: Any) -> None:
@@ -309,8 +308,8 @@ class FloatArray(FieldType):
         return "ARRAY<FLOAT64>"
 
     @staticmethod
-    def grpc_type() -> type_pb2.Type:
-        return type_pb2.Type(code=type_pb2.ARRAY)
+    def grpc_type() -> SpannerType:
+        return SpannerType(code=TypeCode.ARRAY)
 
     @staticmethod
     def validate_type(value: Any) -> None:
@@ -329,8 +328,8 @@ class DateArray(FieldType):
         return "ARRAY<DATE>"
 
     @staticmethod
-    def grpc_type() -> type_pb2.Type:
-        return type_pb2.Type(code=type_pb2.ARRAY)
+    def grpc_type() -> SpannerType:
+        return SpannerType(code=TypeCode.ARRAY)
 
     @staticmethod
     def validate_type(value: Any) -> None:
@@ -353,8 +352,8 @@ class Timestamp(FieldType):
         return "TIMESTAMP"
 
     @staticmethod
-    def grpc_type() -> type_pb2.Type:
-        return type_pb2.Type(code=type_pb2.TIMESTAMP)
+    def grpc_type() -> SpannerType:
+        return SpannerType(code=TypeCode.TIMESTAMP)
 
     @staticmethod
     def validate_type(value: Any) -> None:

--- a/spanner_orm/field.py
+++ b/spanner_orm/field.py
@@ -16,6 +16,7 @@
 
 import abc
 import datetime
+import json
 from typing import Any, Type, Optional
 
 from spanner_orm import error
@@ -344,6 +345,28 @@ class Timestamp(FieldType):
             raise error.ValidationError("{} is not of type datetime".format(value))
 
 
+class Json(FieldType):
+    """Represents a JSON type."""
+
+    @staticmethod
+    def ddl() -> str:
+        return "JSON"
+
+    @staticmethod
+    def grpc_type() -> SpannerType:
+        return SpannerType(code=TypeCode.JSON)
+
+    @staticmethod
+    def validate_type(value: Any) -> None:
+        if not isinstance(value, str):
+            raise error.ValidationError("{} is not of type str".format(value))
+
+        try:
+            json.loads(value)
+        except:
+            raise error.ValidationError("{} is not a valid JSON".format(value))
+
+
 ALL_TYPES = [
     Boolean,
     Integer,
@@ -357,4 +380,5 @@ ALL_TYPES = [
     IntegerArray,
     FloatArray,
     DateArray,
+    Json,
 ]

--- a/spanner_orm/field.py
+++ b/spanner_orm/field.py
@@ -202,23 +202,6 @@ class Bytes(FieldType):
             raise error.ValidationError("{} is not of type bytes".format(value))
 
 
-class Bytes(FieldType):
-    """Represents a bytes type."""
-
-    @staticmethod
-    def ddl(size="MAX") -> str:
-        return "BYTES({size})".format(size=size)
-
-    @staticmethod
-    def grpc_type() -> SpannerType:
-        return SpannerType(code=TypeCode.BYTES)
-
-    @staticmethod
-    def validate_type(value) -> None:
-        if not isinstance(value, bytes):
-            raise error.ValidationError("{} is not of type bytes".format(value))
-
-
 class Date(FieldType):
     """Represents a date type."""
 

--- a/spanner_orm/table_apis.py
+++ b/spanner_orm/table_apis.py
@@ -18,8 +18,12 @@ import logging
 from typing import Any, Dict, Iterable, List
 
 from google.cloud import spanner
-from google.cloud.spanner_v1 import transaction as spanner_transaction
-from google.cloud.spanner_v1.proto import type_pb2
+from google.cloud.spanner_v1 import (
+    Type as SpannerType,
+)
+from google.cloud.spanner_v1 import (
+    transaction as spanner_transaction,
+)
 
 _logger = logging.getLogger(__name__)
 
@@ -55,8 +59,8 @@ def sql_query(
     transaction: spanner_transaction.Transaction,
     query: str,
     parameters: Dict[str, Any],
-    parameter_types: Dict[str, type_pb2.Type],
-    **kwargs
+    parameter_types: Dict[str, SpannerType],
+    **kwargs,
 ) -> List[Iterable[Any]]:
     """Executes a given SQL query against the Spanner database.
 

--- a/spanner_orm/tests/models.py
+++ b/spanner_orm/tests/models.py
@@ -14,10 +14,7 @@
 # limitations under the License.
 """Models used by unit tests."""
 
-from spanner_orm import field
-from spanner_orm import index
-from spanner_orm import model
-from spanner_orm import relationship
+from spanner_orm import field, index, model, relationship
 
 
 class SmallTestModel(model.Model):
@@ -114,6 +111,7 @@ class UnittestModel(model.Model):
     date = field.Field(field.Date, nullable=True)
     bytes_ = field.Field(field.Bytes, nullable=True)
     bytes_2 = field.Field(field.Bytes, nullable=True, size=2048)
+    json = field.Field(field.Json, nullable=True)
     bool_array = field.Field(field.BoolArray, nullable=True)
     int_array = field.Field(field.IntegerArray, nullable=True)
     float_array = field.Field(field.FloatArray, nullable=True)

--- a/spanner_orm/tests/query_test.py
+++ b/spanner_orm/tests/query_test.py
@@ -18,13 +18,11 @@ import unittest
 from unittest import mock
 
 from absl.testing import parameterized
-from spanner_orm import condition
-from spanner_orm import error
-from spanner_orm import field
-from spanner_orm import query
-from spanner_orm.tests import models
+from google.cloud.spanner_v1 import Type as SpannerType
+from google.cloud.spanner_v1 import TypeCode
 
-from google.cloud.spanner_v1.proto import type_pb2
+from spanner_orm import condition, error, field, query
+from spanner_orm.tests import models
 
 
 def now():
@@ -211,7 +209,7 @@ class QueryTest(parameterized.TestCase):
             expected_sql = " WHERE table.{} {} UNNEST(@{})".format(
                 column, current_condition.operator, column_key
             )
-            list_type = type_pb2.Type(code=type_pb2.ARRAY, array_element_type=grpc_type)
+            list_type = SpannerType(code=TypeCode.ARRAY, array_element_type=grpc_type)
             self.assertEndsWith(select_query.sql(), expected_sql)
             self.assertEqual(select_query.parameters(), {column_key: values})
             self.assertEqual(select_query.types(), {column_key: list_type})

--- a/spanner_orm/tests/update_test.py
+++ b/spanner_orm/tests/update_test.py
@@ -16,8 +16,7 @@ import logging
 import unittest
 from unittest import mock
 
-from spanner_orm import error, relationship
-from spanner_orm import field
+from spanner_orm import error, field, relationship
 from spanner_orm.admin import update
 from spanner_orm.index import Index
 from spanner_orm.tests import models
@@ -112,6 +111,7 @@ class UpdateTest(unittest.TestCase):
             " date DATE,"
             " bytes_ BYTES(MAX),"
             " bytes_2 BYTES(2048),"
+            " json JSON,"
             " bool_array ARRAY<BOOL>,"
             " int_array ARRAY<INT64>,"
             " float_array ARRAY<FLOAT64>,"
@@ -146,6 +146,7 @@ class UpdateTest(unittest.TestCase):
                     name="timestamp_2",
                 ),
                 "date": field.Field(field.Date, nullable=True, name="date"),
+                "json": field.Field(field.Json, nullable=True, name="json"),
                 "bool_array": field.Field(
                     field.BoolArray, nullable=True, name="bool_array"
                 ),
@@ -176,6 +177,7 @@ class UpdateTest(unittest.TestCase):
             " timestamp TIMESTAMP NOT NULL,"
             " timestamp_2 TIMESTAMP OPTIONS (allow_commit_timestamp=true),"
             " date DATE,"
+            " json JSON,"
             " bool_array ARRAY<BOOL>,"
             " int_array ARRAY<INT64>,"
             " float_array ARRAY<FLOAT64>,"


### PR DESCRIPTION
## Jira issue
[CCORE-1335](https://unicoidtech.atlassian.net/browse/CCORE-1335)

## Change description

Update `google-cloud-spanner` library to latest version and add support to `JSON` field type.

## Evidences

### Before

Error parsing JSON types.

![image](https://github.com/user-attachments/assets/bffa72cf-819a-438c-91bc-36c76dd739e6)

### After
![image](https://github.com/user-attachments/assets/9a437197-53e4-429d-b116-8fdf4123ce28)

[CCORE-1335]: https://unicoidtech.atlassian.net/browse/CCORE-1335?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ